### PR TITLE
Add SAM CLI template.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,7 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# AWS SAM CLI artifacts
+packaged.yaml
+.aws-sam

--- a/README
+++ b/README
@@ -1,8 +1,0 @@
-webhook_receiver.py is the proof-of-concept webhook receiver lambda that BHayden used in a private AWS account for prototyping. It can be used as an example for how to connect to the Box API.
-
-In order to create the environment for the lambda, I launched an EC2 instance with the Amazon Linux 2 AMI, then followed the instructions here to setup a dependency .zip file:
-https://docs.aws.amazon.com/lambda/latest/dg/lambda-python-how-to-create-deployment-package.html
-
-The only install command needed for the box sdk is:
-pip install "boxsdk[jwt]"
-

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ $ sam build
 $ sam package --s3-bucket your-s3-bucket --output-template packaged.yaml
 $ sam deploy --template-file packaged.yaml --capabilities CAPABILITY_IAM --stack-name your-cloud-formation-stack --parameter-overrides SecretArn=your-secret-arn ManifestTableName=your-ddb-table-name
 ```
+
+The S3 bucket and Secrets Manager secret must already exist.  The DynamoDB table is created as part of the CloudFormation stack.
+
 ## Local testing
 
 The SAM CLI and sample events make it easy to test the webhook function locally.  The CLI uses Docker to run the Lambda code in a container, so you'll need to [install it](https://docs.docker.com/install/).

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Next, run the following commands:
 ```console
 $ sam build
 $ sam package --s3-bucket your-s3-bucket --output-template packaged.yaml
-$ sam deploy --template-file packaged.yaml --capabilities CAPABILITY_IAM --stack-name your-cloud-formation-stack
+$ sam deploy --template-file packaged.yaml --capabilities CAPABILITY_IAM --stack-name your-cloud-formation-stack --parameter-overrides SecretArn=your-secret-arn ManifestTableName=your-ddb-table-name
 ```
 ## Local testing
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,10 @@ this:
 
 ```json
 {
-    "BoxWebhookFunction": { "MANIFEST_TABLE_NAME": "your-ddb-table-name" }
+    "BoxWebhookFunction": {
+        "MANIFEST_TABLE_NAME": "your-ddb-table-name",
+        "SECRET_ARN": "your-secret-arn"
+    }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Notebook data redirector
+
+This is an AWS application that redirects requests to files publicly hosted on Box.
+
+## Deployment
+
+To deploy the redirector, first install and configure the [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) and [Docker](https://docs.docker.com/install/).
+
+Next, run the following commands:
+
+```console
+$ sam build
+$ sam package --s3-bucket your-s3-bucket --output-template packaged.yaml
+$ sam deploy --template-file packaged.yaml --capabilities CAPABILITY_IAM --stack-name your-cloud-formation-stack
+```
+## Local testing
+
+The SAM CLI and sample events make it easy to test the webhook function locally:
+
+```console
+$ sam build
+$ sam local invoke "BoxWebhookFunction" -e your-sample-event.json
+```
+
+Note that this will interact with the live DynamoDB table, so proceed with caution.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is an AWS application that redirects requests to files publicly hosted on B
 
 ## Deployment
 
-To deploy the redirector, first install and configure the [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) and [Docker](https://docs.docker.com/install/).
+To deploy the redirector, first install and configure the [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html).
 
 Next, run the following commands:
 
@@ -15,7 +15,7 @@ $ sam deploy --template-file packaged.yaml --capabilities CAPABILITY_IAM --stack
 ```
 ## Local testing
 
-The SAM CLI and sample events make it easy to test the webhook function locally:
+The SAM CLI and sample events make it easy to test the webhook function locally.  The CLI uses Docker to run the Lambda code in a container, so you'll need to [install it](https://docs.docker.com/install/).
 
 ```console
 $ sam build

--- a/README.md
+++ b/README.md
@@ -19,7 +19,16 @@ The SAM CLI and sample events make it easy to test the webhook function locally:
 
 ```console
 $ sam build
-$ sam local invoke "BoxWebhookFunction" -e your-sample-event.json
+$ sam local invoke "BoxWebhookFunction" -e your-sample-event.json -n env.json
 ```
 
-Note that this will interact with the live DynamoDB table, so proceed with caution.
+Where `your-sample-event.json` contains a Box webhook event serialized to JSON, and `env.json` contains
+this:
+
+```json
+{
+    "BoxWebhookFunction": { "MANIFEST_TABLE_NAME": "your-ddb-table-name" }
+}
+```
+
+Note that this will interact the Box API and whatever DynamoDB table you specify, so proceed with caution.

--- a/redirector/requirements.txt
+++ b/redirector/requirements.txt
@@ -1,0 +1,15 @@
+asn1crypto==0.24.0
+attrs==19.1.0
+boxsdk==2.5.0
+certifi==2019.6.16
+cffi==1.12.3
+chardet==3.0.4
+cryptography==2.7
+idna==2.8
+pycparser==2.19
+PyJWT==1.7.1
+requests==2.22.0
+requests-toolbelt==0.9.1
+six==1.12.0
+urllib3==1.25.3
+wrapt==1.11.2

--- a/redirector/webhook_receiver.py
+++ b/redirector/webhook_receiver.py
@@ -4,6 +4,7 @@ import logging
 import json
 
 MANIFEST_TABLE_NAME = os.environ["MANIFEST_TABLE_NAME"]
+SECRET_ARN = os.environ["SECRET_ARN"]
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -13,19 +14,16 @@ def get_secret():
     import base64
     from botocore.exceptions import ClientError
 
-    secret_name = "BoxApiCredentials"
-    region_name = "us-east-1"
-
     # Create a Secrets Manager client
     session = boto3.session.Session()
-    client = session.client(service_name="secretsmanager", region_name=region_name)
+    client = session.client(service_name="secretsmanager")
 
     # In this sample we only handle the specific exceptions for the 'GetSecretValue' API.
     # See https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html
     # We rethrow the exception by default.
 
     try:
-        get_secret_value_response = client.get_secret_value(SecretId=secret_name)
+        get_secret_value_response = client.get_secret_value(SecretId=SECRET_ARN)
     except ClientError as e:
         if e.response["Error"]["Code"] == "DecryptionFailureException":
             # Secrets Manager can't decrypt the protected secret text using the provided KMS key.

--- a/redirector/webhook_receiver.py
+++ b/redirector/webhook_receiver.py
@@ -1,11 +1,12 @@
 import boto3
 import os
 import logging
+import json
+
+MANIFEST_TABLE_NAME = os.environ["MANIFEST_TABLE_NAME"]
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
-
-validate_webhook = False
 
 
 def get_secret():
@@ -51,7 +52,7 @@ def get_secret():
         # Depending on whether the secret is a string or binary, one of these fields will be populated.
         if "SecretString" in get_secret_value_response:
             secret = get_secret_value_response["SecretString"]
-            return eval(secret)
+            return json.loads(secret)
         else:
             logger.error("binary secret not implemented")
             # raise NotImplementedError
@@ -99,12 +100,12 @@ def get_box_client(app_user=True):
         return appClient, WEBHOOK_KEY
 
 
-def get_file_id_and_hash(webhook_event, box_client):
-    file_id = webhook_event["body"]["source"]["item"]["id"]
+def get_file_id_and_hash(event_body, box_client):
+    file_id = event_body["source"]["item"]["id"]
     box_file = box_client.file(file_id=file_id)
     filename = box_file.get().name
 
-    hashed_url = webhook_event["body"]["source"]["url"]
+    hashed_url = event_body["source"]["url"]
     try:
         box_hash = hashed_url.split("/")[-1]
     except AttributeError:
@@ -117,51 +118,48 @@ def get_file_id_and_hash(webhook_event, box_client):
 
 
 def lambda_handler(event, context):
-
+    body = json.loads(event["body"])
     # only get a box client if we're actually going to need one
     handled_triggers = [
         "SHARED_LINK.CREATED",
         "SHARED_LINK.UPDATED",
         "SHARED_LINK.DELETED",
     ]
-    if event["body"]["trigger"] in handled_triggers:
+    if body["trigger"] in handled_triggers:
         client, webhook_key = get_box_client(app_user=True)
         ddb = boto3.resource("dynamodb", region_name="us-east-1").Table(
-            "BoxWebhookTest"
+            MANIFEST_TABLE_NAME
         )
         logger.info(event)
     else:
-        logger.info(f"{event['body']['trigger']} is not supported by this endpoint")
+        logger.info(f"{body['trigger']} is not supported by this endpoint")
         return {"statusCode": 200}
 
-    if validate_webhook:
-        logger.info(event["body"])
-        logger.info(event["headers"])
-        webhook = client.webhook(event["body"]["webhook"]["id"])
-        is_valid = webhook.validate_message(
-            bytes(f"{event['body']}", "utf-8"), event["headers"], webhook_key
-        )
-        if not is_valid:
-            logger.info(f"received invalid webhook")
-            logger.critical(event)
-            return {"statusCode": 200}
+    webhook = client.webhook(body["webhook"]["id"])
+    is_valid = webhook.validate_message(
+        bytes(f"{event['body']}", "utf-8"), event["headers"], webhook_key
+    )
+    if not is_valid:
+        logger.info(f"received invalid webhook")
+        logger.critical(event)
+        return {"statusCode": 200}
 
-    if event["body"]["trigger"] == "SHARED_LINK.CREATED":
-        filename, box_hash = get_file_id_and_hash(event, client)
+    if body["trigger"] == "SHARED_LINK.CREATED":
+        filename, box_hash = get_file_id_and_hash(body, client)
 
-        put_item = {"Filename": filename, "hash": box_hash}
+        put_item = {"filename": filename, "hash": box_hash}
         ddb.put_item(Item=put_item)
 
-    elif event["body"]["trigger"] == "SHARED_LINK.DELETED":
+    elif body["trigger"] == "SHARED_LINK.DELETED":
         from boto3.dynamodb.conditions import Key
 
-        filename, box_hash = get_file_id_and_hash(event, client)
+        filename, box_hash = get_file_id_and_hash(body, client)
 
         all_items = ddb.query(KeyConditionExpression=Key("Filename").eq(filename))
         for item in all_items["Items"]:
             ddb.delete_item(Key=item)
 
-    elif event["body"]["trigger"] == "SHARED_LINK.UPDATED":
+    elif body["trigger"] == "SHARED_LINK.UPDATED":
         logger.info(
             "SHARED_LINK.UPDATED was not implemented because I cannot figure out what triggers them and what the event looks like"
         )

--- a/template.yaml
+++ b/template.yaml
@@ -34,6 +34,7 @@ Resources:
       Environment:
         Variables:
           MANIFEST_TABLE_NAME: !Ref ManifestTableName
+          SECRET_ARN: !Ref SecretArn
       Events:
         BoxWebhookEvent:
           Type: Api

--- a/template.yaml
+++ b/template.yaml
@@ -1,0 +1,61 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: >
+  notebook-data-redirector
+
+  SAM template for notebook data redirector
+
+Parameters:
+  ManifestTableName:
+    Type: String
+    Description: Name of the DynamoDB manifest table
+  SecretArn:
+    Type: String
+    Description: ARN of the Secrets Manager secret containing Box JWT credentials
+
+Resources:
+  ManifestTable:
+    Type: AWS::Serverless::SimpleTable
+    Properties:
+      TableName: !Ref ManifestTableName
+      PrimaryKey:
+        Name: filename
+        Type: String
+
+  BoxWebhookFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      MemorySize: 128
+      # Box retries after 30 seconds, so we should give up at that point, too:
+      Timeout: 30
+      Handler: webhook_receiver.lambda_handler
+      Runtime: python3.7
+      CodeUri: redirector/
+      Environment:
+        Variables:
+          MANIFEST_TABLE_NAME: !Ref ManifestTableName
+      Events:
+        BoxWebhookEvent:
+          Type: Api
+          Properties:
+            Path: /webhook
+            Method: post
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref ManifestTableName
+        - AWSSecretsManagerGetSecretValuePolicy:
+            SecretArn: !Ref SecretArn
+
+Outputs:
+  RedirectorApi:
+    Description: "API Gateway endpoint URL"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/"
+  BoxWebhookFunction:
+    Description: "BoxWebhookFunction ARN"
+    Value: !GetAtt BoxWebhookFunction.Arn
+  BoxWebhookFunctionIamRole:
+    Description: "Implicit IAM Role created for BoxWebhookFunction"
+    Value: !GetAtt BoxWebhookFunctionRole.Arn
+  DynamoDBTableName:
+    Description: "Name of the manifest table in DynamoDB"
+    Value: !Ref ManifestTableName


### PR DESCRIPTION
This adds initial support for deploying the redirector with the SAM CLI.  I made only minor changes to webhook_receiver.py:

- Pass DynamoDB table name in as an environment variable (so it could be configured as a template parameter)
- Reconstitute the secret payload with json.loads instead of eval
- Handle the event as a LAMBDA_PROXY event

I also added a few sample Box webhook events, since those are hard to come by.