### PR TITLE
merge security updates to develop

### DIFF
--- a/notebook_data_redirector/common.py
+++ b/notebook_data_redirector/common.py
@@ -203,7 +203,6 @@ def _get_secret():
     try:
         response = client.get_secret_value(SecretId=SECRET_ARN)
     except client.exceptions.ClientError:  # pragma: no cover
-
         sts_client = boto3.client("sts")
         assumed_role_object = sts_client.assume_role(RoleArn=SECRET_ROLE_ARN, RoleSessionName="AssumeRoleSession1")
 

--- a/notebook_data_redirector/requirements.txt
+++ b/notebook_data_redirector/requirements.txt
@@ -1,13 +1,13 @@
 asn1crypto==0.24.0
 attrs~=19.2
 boxsdk==2.5.0
-certifi==2019.6.16
+certifi==2022.12.7
 cffi==1.12.3
 chardet==3.0.4
-cryptography==3.3.2
+cryptography==39.0.1
 idna==2.8
 pycparser==2.19
-PyJWT==1.7.1
+PyJWT==2.4.0
 requests~=2.22
 requests-toolbelt==0.9.1
 six==1.12.0

--- a/notebook_data_redirector/webhook_receiver.py
+++ b/notebook_data_redirector/webhook_receiver.py
@@ -79,7 +79,6 @@ def lambda_handler(event, context):
 
         folder_shared = common.is_box_object_public(folder)
         for file, shared in common.iterate_files(folder, shared=folder_shared):
-
             # if the file isn't public but any parent directory is
             if (not common.is_box_object_public(file)) and shared:
                 # this includes an api call


### PR DESCRIPTION
* Bump cryptography from 2.7 to 3.2 in /notebook_data_redirector

Bumps [cryptography](https://github.com/pyca/cryptography) from 2.7 to 3.2.
- [Release notes](https://github.com/pyca/cryptography/releases)
- [Changelog](https://github.com/pyca/cryptography/blob/master/CHANGELOG.rst)
- [Commits](https://github.com/pyca/cryptography/compare/2.7...3.2)

Signed-off-by: dependabot[bot] <support@github.com>

* Bump urllib3 from 1.25.3 to 1.26.5 in /notebook_data_redirector

Bumps [urllib3](https://github.com/urllib3/urllib3) from 1.25.3 to 1.26.5.
- [Release notes](https://github.com/urllib3/urllib3/releases)
- [Changelog](https://github.com/urllib3/urllib3/blob/main/CHANGES.rst)
- [Commits](https://github.com/urllib3/urllib3/compare/1.25.3...1.26.5)

---
updated-dependencies:
- dependency-name: urllib3 dependency-type: direct:production ...

Signed-off-by: dependabot[bot] <support@github.com>

* Bump cryptography from 3.2 to 3.3.2 in /notebook_data_redirector

Bumps [cryptography](https://github.com/pyca/cryptography) from 3.2 to 3.3.2.
- [Release notes](https://github.com/pyca/cryptography/releases)
- [Changelog](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst)
- [Commits](https://github.com/pyca/cryptography/compare/3.2...3.3.2)

---
updated-dependencies:
- dependency-name: cryptography dependency-type: direct:production ...

Signed-off-by: dependabot[bot] <support@github.com>

* Feature/GitHub actions (#29)

* Bump pyjwt from 1.7.1 to 2.4.0 in /notebook_data_redirector (#31)

Bumps [pyjwt](https://github.com/jpadilla/pyjwt) from 1.7.1 to 2.4.0.
- [Release notes](https://github.com/jpadilla/pyjwt/releases)
- [Changelog](https://github.com/jpadilla/pyjwt/blob/master/CHANGELOG.rst)
- [Commits](https://github.com/jpadilla/pyjwt/compare/1.7.1...2.4.0)

---
updated-dependencies:
- dependency-name: pyjwt dependency-type: direct:production ...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* Bump certifi from 2019.6.16 to 2022.12.7 in /notebook_data_redirector (#32)

Bumps [certifi](https://github.com/certifi/python-certifi) from 2019.6.16 to 2022.12.7.
- [Release notes](https://github.com/certifi/python-certifi/releases)
- [Commits](https://github.com/certifi/python-certifi/compare/2019.06.16...2022.12.07)

---
updated-dependencies:
- dependency-name: certifi dependency-type: direct:production ...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

* Bump cryptography from 3.3.2 to 39.0.1 in /notebook_data_redirector (#33)

* Bump cryptography from 3.3.2 to 39.0.1 in /notebook_data_redirector

Bumps [cryptography](https://github.com/pyca/cryptography) from 3.3.2 to 39.0.1.
- [Release notes](https://github.com/pyca/cryptography/releases)
- [Changelog](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst)
- [Commits](https://github.com/pyca/cryptography/compare/3.3.2...39.0.1)

---
updated-dependencies:
- dependency-name: cryptography dependency-type: direct:production ...

Signed-off-by: dependabot[bot] <support@github.com>

* black

---------

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Co-authored-by: Brian Hayden <5826711+bhayden53@users.noreply.github.com>

---------

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>